### PR TITLE
Add null check to avoid 500 error when viewing the changes for the README.md file itself

### DIFF
--- a/lib/display_readme.rb
+++ b/lib/display_readme.rb
@@ -15,7 +15,9 @@ class DisplayReadme < Redmine::Hook::ViewListener
       return ''
     end
 
-    raw_readme_text = repo.cat(file.path, rev)
+    unless raw_readme_text = repo.cat(file.path, rev)
+      return ''
+    end
 
     formatter_name = ''
     if @@markdown_ext.include?(File.extname(file.path))


### PR DESCRIPTION
Hi there,

I added a small check to avoid a 500 error in a small corner case. I think it could be useful to other people as well :-).

Regards,
Antonio
