### PR TITLE
Only look for README in directories

### DIFF
--- a/lib/display_readme.rb
+++ b/lib/display_readme.rb
@@ -11,6 +11,11 @@ class DisplayReadme < Redmine::Hook::ViewListener
     blk = repo_id ? lambda { |r| r.identifier == repo_id } : lambda { |r| r.is_default }
     repo = context[:project].repositories.find &blk
 
+    entry = repo.entry(path)
+    if not entry.is_dir?
+      return ''
+    end
+
     unless file = (repo.entries(path, rev) || []).find { |entry| entry.name =~ /README((\.).*)?/i }
       return ''
     end


### PR DESCRIPTION
for scm: filesystem provider at least, this plugin causes an exception when trying to read  "file/README" as 'file' is not a directory.