### PR TITLE
Fix project settings not working (mass assignment, incorrect ids)

### DIFF
--- a/app/controllers/rar_project_settings_controller.rb
+++ b/app/controllers/rar_project_settings_controller.rb
@@ -10,7 +10,7 @@ class RarProjectSettingsController < ApplicationController
 
   def update
     project_id = params[:project_id]
-    r = RarProjectSetting.find(project_id)
+    r = RarProjectSetting.find_or_create_by(project_id: project_id)
     r.position = params[:rar_project_setting][:position]
     r.show = params[:rar_project_setting][:show]
     res = r.save

--- a/app/models/rar_project_setting.rb
+++ b/app/models/rar_project_setting.rb
@@ -1,3 +1,7 @@
 class RarProjectSetting < ActiveRecord::Base
   unloadable
+
+  if defined?(ProtectedAttributes) || ::ActiveRecord::VERSION::MAJOR < 4
+    attr_accessible :project_id, :position, :show
+  end
 end

--- a/lib/display_readme.rb
+++ b/lib/display_readme.rb
@@ -4,7 +4,8 @@ class DisplayReadme < Redmine::Hook::ViewListener
 
   def view_repositories_show_contextual(context)
 
-    return if EnabledModule.where(:project_id => context[:project].id, :name => 'readme_at_repository').empty?
+    return if EnabledModule.where(:project_id => context[:project].id, :name => 'readme_at_repository').empty? ||
+      RarProjectSetting.find_by(project_id: context[:project].id).nil?
 
     path = context[:request].params['path'] || ''
     rev = (_rev = context[:request].params['rev']).blank? ? nil : _rev
@@ -33,7 +34,7 @@ class DisplayReadme < Redmine::Hook::ViewListener
 
     formatter = Redmine::WikiFormatting.formatter_for(formatter_name).new(raw_readme_text)
 
-    rar_setting = RarProjectSetting.find(context[:project].id)
+    rar_setting = RarProjectSetting.find_by(project_id: context[:project].id)
 
     context[:controller].send(:render_to_string, {
       :partial => 'repository/readme',


### PR DESCRIPTION
The project settings did not work for me - one reason was that the settings were in some cases queried by the `settings_id`, but the `project_id` was passed.

Also `find_or_create_by` did not work for me (Redmine 3.0.2, Rails 4.2.1) because the `protected_attributes` gem prevented the mass assignment of the `project_id`. Due to the non-critical nature of these settings I just enabled mass assignment of the settings properties.