### PR TITLE
[~] support for README file names starting with '!', e.g. '!README.md'

### DIFF
--- a/app/views/repository/_readme.html.erb
+++ b/app/views/repository/_readme.html.erb
@@ -1,4 +1,4 @@
-<h2 id="toggle_readme_block"><a>README</a></h2>
+<h2 id="toggle_readme_block"><a style="cursor: pointer;">README</a></h2>
 <div id="readme_at_repo_dir" class="wiki" <% if show == 0%>style="display: none;"<% end %>>
   <% if html.html_safe.respond_to?(:force_encoding) %>
     <%= html.html_safe.force_encoding('UTF-8') %>

--- a/lib/display_readme.rb
+++ b/lib/display_readme.rb
@@ -19,7 +19,7 @@ class DisplayReadme < Redmine::Hook::ViewListener
       return ''
     end
 
-    unless file = (repo.entries(path, rev) || []).find { |entry| entry.name =~ /README((\.).*)?/i }
+    unless file = (repo.entries(path, rev) || []).find { |entry| entry.name =~ /!?README((\.).*)?/i }
       return ''
     end
 


### PR DESCRIPTION
[~] expand/collapse hyperlink of the README section now has a "pointer" type cursor

Not my code, but I like the changes.